### PR TITLE
Locked virtual machines must not have expiration time

### DIFF
--- a/berta.gemspec
+++ b/berta.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'chronic_duration', '~> 0.10'
   s.add_runtime_dependency 'mail', '~> 2.6'
-  s.add_runtime_dependency 'opennebula', '~> 5.2'
+  s.add_runtime_dependency 'opennebula', '~> 5.8'
   s.add_runtime_dependency 'settingslogic', '~> 2.0'
   s.add_runtime_dependency 'thor', '~> 0.19'
   s.add_runtime_dependency 'tilt', '~> 2.0'

--- a/lib/berta/service.rb
+++ b/lib/berta/service.rb
@@ -43,7 +43,7 @@ module Berta
     def running_vms
       return @cached_vms if @cached_vms
       vm_pool = OpenNebula::VirtualMachinePool.new(client)
-      Berta::Utils::OpenNebula::Helper.handle_error { vm_pool.info_all }
+      Berta::Utils::OpenNebula::Helper.handle_error { vm_pool.info_all_extended }
       logger.debug "Fetched vms: #{vm_pool.map(&:id)}"
       @cached_vms = @filter.run(vm_pool.map { |vm| Berta::VirtualMachineHandler.new(vm) })
       @cached_vms

--- a/lib/berta/utils/filter.rb
+++ b/lib/berta/utils/filter.rb
@@ -27,6 +27,10 @@ module Berta
       def run(vmhs)
         fvmhs = vmhs.select { |vmh| takes_resources?(vmh) }
         logger.debug "Filtered based on RESOURCE: #{(vmhs - fvmhs).map { |vmh| vmh.handle.id }}"
+
+        locked_vmhs, fvmhs = fvmhs.partition { |vmh| is_locked?(vmh) }
+        logger.debug "Filtered based on LOCK: #{locked_vmhs.map { |vmh| vmh.handle.id }}"
+
         fvmhs = filter(fvmhs)
         logger.debug "VMS after filter : #{fvmhs.map { |vmh| vmh.handle.id }}"
         fvmhs
@@ -80,6 +84,10 @@ module Berta
 
       def takes_resources?(vmh)
         !IGNORED_STATES.include?(vmh.handle.state_str)
+      end
+
+      def is_locked?(vmh)
+        vmh.handle['LOCK/LOCKED'] && vmh.handle['LOCK/LOCKED'] != '0'
       end
 
       def log_filter

--- a/spec/berta/utils/filter_spec.rb
+++ b/spec/berta/utils/filter_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 class TestHandle
-  def initialize(state)
+
+  def initialize(state, locked)
     @state = state
+    @template = {}
+
+    @template['LOCK/LOCKED'] = 1 if locked
   end
 
   def state_str
@@ -12,13 +16,18 @@ class TestHandle
   def id
     0
   end
+
+  def [](key)
+    @template[key]
+  end
+
 end
 
 class TestVM
   attr_reader :handle
 
-  def initialize(state)
-    @handle = TestHandle.new(state)
+  def initialize(state, locked=false)
+    @handle = TestHandle.new(state, locked)
   end
 end
 
@@ -29,6 +38,7 @@ describe Berta::Utils::Filter do
 
       it 'filters out IGNORED_STATES' do
         vms = [TestVM.new('RUNNING'),
+               TestVM.new('RUNNING', locked=true),
                TestVM.new('PENDING'),
                TestVM.new('STOPPED'),
                TestVM.new('PENDING'),


### PR DESCRIPTION
Since OpenNebula 5.8, virtual machines can be locked to prevent
unwanted actions.

Berta must respect the lock state.

* berta.gemspec: require OpenNebula 5.8 API.

* lib/berta/service.rb (Berta::Service#running_vms): ask for extended
  information to retrive lock state.

* lib/berta/utils/filter.rb (Berta::Utils::Filter#run): exclude locked
  virtual machines.
  (Berta::Utils::Filter#is_locked?): new predicate to check if a
  virtual machine is locked.