### PR TITLE
fix(api): use 6.2+ scheduled action API

### DIFF
--- a/berta.gemspec
+++ b/berta.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'chronic_duration', '~> 0.10'
   s.add_runtime_dependency 'mail', '~> 2.6'
-  s.add_runtime_dependency 'opennebula', '~> 5.8'
+  s.add_runtime_dependency 'opennebula', '>= 6.2', '<= 6.4'
   s.add_runtime_dependency 'settingslogic', '~> 2.0'
   s.add_runtime_dependency 'thor', '~> 0.19'
   s.add_runtime_dependency 'tilt', '~> 2.0'

--- a/lib/berta/entities/expiration.rb
+++ b/lib/berta/entities/expiration.rb
@@ -9,9 +9,14 @@ module Berta
       # @param xml [XMLElement] XML from which to create instance
       # @return [Berta::Entities::Expiration] Expiration from given xml
       # @raise [Berta::Errors::Entities::InvalidEntityXMLError] If XMLElement was not in correct format
-      def self.from_xml(xml)
+      def self.from_xml(xml, start_time=0)
         check_xml!(xml)
-        Berta::Entities::Expiration.new(xml['ID'], xml['TIME'], xml['ACTION'])
+        time = if xml['TIME'].start_with?('+')
+                 start_time + xml['TIME'].to_i
+               else
+                 xml['TIME']
+               end
+        Berta::Entities::Expiration.new(xml['ID'], time, xml['ACTION'])
       end
 
       # Raises error if XML element is not in correct format.
@@ -37,7 +42,7 @@ module Berta
       end
 
       # Generate schelude action template that can be used
-      # in VMS USER_TEMPLATE/SCHED_ACTION
+      # in VMS TEMPLATE/SCHED_ACTION
       #
       # @return [String] Schelude action template
       def template
@@ -45,7 +50,9 @@ module Berta
       SCHED_ACTION = [
           ID     = "#{id}",
           ACTION = "#{action}",
-          TIME   = "#{time}"
+          TIME   = "#{time}",
+          END_TYPE = "2",
+          END_VALUE = "#{time}"
       ]
       VM_TEMPLATE
       end


### PR DESCRIPTION
* berta.gemspec: require opennebula library between 6.2 and 6.4.

* lib/berta/entities/expiration.rb (Berta::Entities::Expiration.from_xml):
  expiration can be relative to the start time of the virtual machine,
  always make it a full timestamp.

* lib/berta/entities/expiration.rb (Berta::Entities::Expiration#template):
  create punctual schedule action with required `END_TYPE`.

* lib/berta/virtual_machine_handler.rb (Berta::VirtualMachineHandler):
  instead of updating the VM template, use the `sched_action_add` and
  `sched_action_delete` API directly.
  Lookup scheduled action under `TEMPLATE` instead of old `USER_TEMPLATE`.

Fixes: #12 